### PR TITLE
Fix #3213 - Change all references of rudder 2.4 to be 2.5 compliant

### DIFF
--- a/10_install_server/11_install_root_server_debian.txt
+++ b/10_install_server/11_install_root_server_debian.txt
@@ -43,7 +43,7 @@ Then add the Rudder repository, by typing:
 
 ----
 
-root@rudder-server:~# echo "deb http://www.rudder-project.org/apt-2.4/ $(lsb_release -cs) main contrib non-free" > /etc/apt/sources.list.d/rudder.list
+root@rudder-server:~# echo "deb http://www.rudder-project.org/apt-2.5/ $(lsb_release -cs) main contrib non-free" > /etc/apt/sources.list.d/rudder.list
 
 ----
 

--- a/10_install_server/12_install_root_server_sles.txt
+++ b/10_install_server/12_install_root_server_sles.txt
@@ -24,7 +24,7 @@ Add the URL of the Normation repository, by typing the next command on a SLES 11
 ----
 
 root@rudder-server:~# zypper ar -n "Normation RPM Repositories" \
-http://www.rudder-project.org/rpm-2.4/SLES_11_SP1/ Normation
+http://www.rudder-project.org/rpm-2.5/SLES_11_SP1/ Normation
 
 ----
 
@@ -32,7 +32,7 @@ Or this one on a SLES 10:
 
 ----
 
-root@rudder-server:~# zypper sa "http://www.rudder-project.org/rpm-2.4/SLES_10_SP3/" Normation
+root@rudder-server:~# zypper sa "http://www.rudder-project.org/rpm-2.5/SLES_10_SP3/" Normation
 
 ----
 

--- a/10_install_server/13_install_root_server_centos_rhel.txt
+++ b/10_install_server/13_install_root_server_centos_rhel.txt
@@ -20,9 +20,9 @@ Configure the yum repository for RedHat/CentOS 6:
 
 ----
 
-$ echo "[Rudder_2.4]
-name=Rudder 2.4 Repository
-baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_6/
+$ echo "[Rudder_2.5]
+name=Rudder 2.5 Repository
+baseurl=http://www.rudder-project.org/rpm-2.5/RHEL_6/
 gpgcheck=0
 " > /etc/yum.repos.d/rudder.repo
 
@@ -32,9 +32,9 @@ Or for RedHat/CentOS 5:
 
 ----
 
-$ echo "[Rudder_2.4]
-name=Rudder 2.4 Repository
-baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_5/
+$ echo "[Rudder_2.5]
+name=Rudder 2.5 Repository
+baseurl=http://www.rudder-project.org/rpm-2.5/RHEL_5/
 gpgcheck=0
 " > /etc/yum.repos.d/rudder.repo
 

--- a/11_install_agent/10_install_agent_debian.txt
+++ b/11_install_agent/10_install_agent_debian.txt
@@ -23,7 +23,7 @@ Add Rudder project repository:
 ----
 
 sudo tee /etc/apt/sources.list.d/rudder.list <<EOF
-deb http://www.rudder-project.org/apt-2.4/ $(lsb_release -cs) main contrib non-free
+deb http://www.rudder-project.org/apt-2.5/ $(lsb_release -cs) main contrib non-free
 EOF
 
 ----
@@ -32,7 +32,7 @@ EOF
 
 ----
 
-sudo apt-add-repository http://www.rudder-project.org/apt-2.4/
+sudo apt-add-repository http://www.rudder-project.org/apt-2.5/
 
 ----
 

--- a/11_install_agent/20_install_agent_centos_rhel.txt
+++ b/11_install_agent/20_install_agent_centos_rhel.txt
@@ -5,8 +5,8 @@ architecture on
 
 ----
 
-http://www.rudder-project.org/rpm-2.4/RHEL_5/
-http://www.rudder-project.org/rpm-2.4/RHEL_6/
+http://www.rudder-project.org/rpm-2.5/RHEL_5/
+http://www.rudder-project.org/rpm-2.5/RHEL_6/
 
 ----
 
@@ -14,9 +14,9 @@ Or you can define a yum repository for RedHat/CentOS 6:
 
 ----
 
-$ echo "[Rudder_2.4]
-name=Rudder 2.4 Repository
-baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_6/
+$ echo "[Rudder_2.5]
+name=Rudder 2.5 Repository
+baseurl=http://www.rudder-project.org/rpm-2.5/RHEL_6/
 gpgcheck=0
 " > /etc/yum.repos.d/rudder.repo
 
@@ -26,9 +26,9 @@ Or for RedHat/CentOS 5:
 
 ----
 
-$ echo "[Rudder_2.4]
-name=Rudder 2.4 Repository
-baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_5/
+$ echo "[Rudder_2.5]
+name=Rudder 2.5 Repository
+baseurl=http://www.rudder-project.org/rpm-2.5/RHEL_5/
 gpgcheck=0
 " > /etc/yum.repos.d/rudder.repo
 
@@ -39,7 +39,7 @@ Install the package:
 
 ----
 
-rpm -Uhv rudder-agent-2.4.0-1.EL.5.x86_64.rpm
+rpm -Uhv rudder-agent-2.5.0-1.EL.5.x86_64.rpm
 
 ----
 

--- a/11_install_agent/30_install_agent_suse.txt
+++ b/11_install_agent/30_install_agent_suse.txt
@@ -9,7 +9,7 @@ Add the Rudder packages repository:
 ----
 
 zypper ar -n "Rudder RPM Repositories" \
-http://www.rudder-project.org/rpm-2.4/SLES_11_SP1/ Rudder
+http://www.rudder-project.org/rpm-2.5/SLES_11_SP1/ Rudder
 
 ----
 
@@ -17,7 +17,7 @@ http://www.rudder-project.org/rpm-2.4/SLES_11_SP1/ Rudder
 
 ----
 
-zypper sa "http://www.rudder-project.org/rpm-2.4/SLES_10_SP3/" Rudder
+zypper sa "http://www.rudder-project.org/rpm-2.5/SLES_10_SP3/" Rudder
 
 ----
 

--- a/12_upgrade/00_upgrade.txt
+++ b/12_upgrade/00_upgrade.txt
@@ -1,7 +1,7 @@
 == Upgrade Rudder
 
 This short chapter covers the upgrade of the Rudder Server Root and Rudder Agent
-from a version 2.3 to the latest version 2.4. 
+from a version 2.4 to the latest version 2.5. 
 
 The upgrade is quite similar to the installation.
 

--- a/12_upgrade/10_upgrade_debian.txt
+++ b/12_upgrade/10_upgrade_debian.txt
@@ -7,7 +7,7 @@ Add Rudder project repository:
 * on Debian Squeeze and followings or Ubuntu 11.10 and followings:
 ----
 
-echo "deb http://www.rudder-project.org/apt-2.4/ $(lsb_release -cs) main contrib non-free" > /etc/apt/sources.list.d/rudder.list
+echo "deb http://www.rudder-project.org/apt-2.5/ $(lsb_release -cs) main contrib non-free" > /etc/apt/sources.list.d/rudder.list
 
 ----
 
@@ -15,7 +15,7 @@ echo "deb http://www.rudder-project.org/apt-2.4/ $(lsb_release -cs) main contrib
 
 ----
 
-apt-add-repository http://www.rudder-project.org/apt-2.4/
+apt-add-repository http://www.rudder-project.org/apt-2.5/
 
 ----
 

--- a/12_upgrade/20_upgrade_centos_rhel.txt
+++ b/12_upgrade/20_upgrade_centos_rhel.txt
@@ -6,9 +6,9 @@ Define a yum repository for RedHat/CentOS 6:
 
 ----
 
-$ echo "[Rudder_2.4]
-name=Rudder 2.4 Repository
-baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_6/
+$ echo "[Rudder_2.5]
+name=Rudder 2.5 Repository
+baseurl=http://www.rudder-project.org/rpm-2.5/RHEL_6/
 gpgcheck=0
 " > /etc/yum.repos.d/rudder.repo
 
@@ -18,9 +18,9 @@ Or for RedHat/CentOS 5:
 
 ----
 
-$ echo "[Rudder_2.4]
-name=Rudder 2.4 Repository
-baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_5/
+$ echo "[Rudder_2.5]
+name=Rudder 2.5 Repository
+baseurl=http://www.rudder-project.org/rpm-2.5/RHEL_5/
 gpgcheck=0
 " > /etc/yum.repos.d/rudder.repo
 

--- a/12_upgrade/30_upgrade_suse.txt
+++ b/12_upgrade/30_upgrade_suse.txt
@@ -9,7 +9,7 @@ Add the Rudder packages repository:
 ----
 
 zypper ar -n "Rudder RPM Repositories" \
-http://www.rudder-project.org/rpm-2.4/SLES_11_SP1/ Rudder
+http://www.rudder-project.org/rpm-2.5/SLES_11_SP1/ Rudder
 
 ----
 
@@ -17,7 +17,7 @@ http://www.rudder-project.org/rpm-2.4/SLES_11_SP1/ Rudder
 
 ----
 
-zypper sa "http://www.rudder-project.org/rpm-2.4/SLES_10_SP3/" Rudder
+zypper sa "http://www.rudder-project.org/rpm-2.5/SLES_10_SP3/" Rudder
 
 ----
 

--- a/docinfo.xml
+++ b/docinfo.xml
@@ -30,7 +30,7 @@
   </authorgroup>
   
   <copyright>
-    <year>2011-2012</year>
+    <year>2011-2013</year>
     <holder>Normation SAS</holder>
   </copyright>
   
@@ -57,6 +57,14 @@
       <authorinitials>NC, JC, FFT</authorinitials>
       <revremark>
         Rudder User Documentation for 2.4 release of Rudder.
+      </revremark>
+    </revision>
+    <revision>
+      <revnumber>2.5.0</revnumber>
+      <date>January 2013</date>
+      <authorinitials>NC, JC, FFT</authorinitials>
+      <revremark>
+        Rudder User Documentation for 2.5 release of Rudder.
       </revremark>
     </revision>
   </revhistory>

--- a/rudder-doc.txt
+++ b/rudder-doc.txt
@@ -8,8 +8,8 @@ Normation_SAS,_Jonathan_Clarke,_Nicolas_Charles_and_Fabrice_Flore-Thebault <cont
   Configuration Management, FusionInventory, CFEngine Community, +
   CFEngine Nova, CFEngine, Scala, Free Software, Open Source, AGPL +
   User documentation
-:revdate: February 2012
-:revision: 2.4.0
+:revdate: January 2013
+:revision: 2.5.0
 
 // Generate the map of content from list of files and alphabetically ordered
 // glossary 
@@ -33,7 +33,7 @@ include::temp/glossary.txt[]
 [colophon]
 == License
 
-Copyright (C) 2011-2012 Normation SAS
+Copyright (C) 2011-2013 Normation SAS
 
 Rudder User Documentation by http://normation.com[Normation SAS] is licensed under
 a http://creativecommons.org/licenses/by-sa/3.0/[Creative Commons


### PR DESCRIPTION
Fix #3213 - Change all references of rudder 2.4 to be 2.5 compliant
