### PR TITLE
Fixes #3941 - Explain how configure yum repositories to add Rudder and its GPG key

### DIFF
--- a/10_install_server/13_install_root_server_centos_rhel.txt
+++ b/10_install_server/13_install_root_server_centos_rhel.txt
@@ -23,7 +23,8 @@ Configure the yum repository for RedHat/CentOS 6:
 $ echo "[Rudder_2.4]
 name=Rudder 2.4 Repository
 baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_6/
-gpgcheck=0
+gpgcheck=1
+gpgkey=http://www.rudder-project.org/rpm-2.4/RHEL_6/repodata/repomd.xml.key
 " > /etc/yum.repos.d/rudder.repo
 
 ----
@@ -35,7 +36,8 @@ Or for RedHat/CentOS 5:
 $ echo "[Rudder_2.4]
 name=Rudder 2.4 Repository
 baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_5/
-gpgcheck=0
+gpgcheck=1
+gpgkey=http://www.rudder-project.org/rpm-2.4/RHEL_5/repodata/repomd.xml.key
 " > /etc/yum.repos.d/rudder.repo
 
 ----

--- a/11_install_agent/20_install_agent_centos_rhel.txt
+++ b/11_install_agent/20_install_agent_centos_rhel.txt
@@ -17,7 +17,8 @@ Or you can define a yum repository for RedHat/CentOS 6:
 $ echo "[Rudder_2.4]
 name=Rudder 2.4 Repository
 baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_6/
-gpgcheck=0
+gpgcheck=1
+gpgkey=http://www.rudder-project.org/rpm-2.4/RHEL_6/repodata/repomd.xml.key
 " > /etc/yum.repos.d/rudder.repo
 
 ----
@@ -29,7 +30,8 @@ Or for RedHat/CentOS 5:
 $ echo "[Rudder_2.4]
 name=Rudder 2.4 Repository
 baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_5/
-gpgcheck=0
+gpgcheck=1
+gpgkey=http://www.rudder-project.org/rpm-2.4/RHEL_5/repodata/repomd.xml.key
 " > /etc/yum.repos.d/rudder.repo
 
 ----

--- a/12_upgrade/20_upgrade_centos_rhel.txt
+++ b/12_upgrade/20_upgrade_centos_rhel.txt
@@ -9,7 +9,8 @@ Define a yum repository for RedHat/CentOS 6:
 $ echo "[Rudder_2.4]
 name=Rudder 2.4 Repository
 baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_6/
-gpgcheck=0
+gpgcheck=1
+gpgkey=http://www.rudder-project.org/rpm-2.4/RHEL_6/repodata/repomd.xml.key
 " > /etc/yum.repos.d/rudder.repo
 
 ----
@@ -21,7 +22,8 @@ Or for RedHat/CentOS 5:
 $ echo "[Rudder_2.4]
 name=Rudder 2.4 Repository
 baseurl=http://www.rudder-project.org/rpm-2.4/RHEL_5/
-gpgcheck=0
+gpgcheck=1
+gpgkey=http://www.rudder-project.org/rpm-2.4/RHEL_5/repodata/repomd.xml.key
 " > /etc/yum.repos.d/rudder.repo
 
 ----


### PR DESCRIPTION
Fixes #3941 - Explain how configure yum repositories to add Rudder and its GPG key

See http://www.rudder-project.org/redmine/issues/3941
