### PR TITLE
Fixes #3949: document LDAP authentication mixed with rudder-users.xml defined authorization

### DIFF
--- a/4_advanced_usage/21_ldap_authentication_provider.txt
+++ b/4_advanced_usage/21_ldap_authentication_provider.txt
@@ -11,6 +11,15 @@ We will take LDAP as an example, however bear in mind that this procedure
 requires that you make modifications to your application that an update will
 replace, we do not officially support it yet.
 
+
+Also take care of the following limitation of the current process: only *authentication*
+is delegated to LDAP, NOT *authorizations*. So you still have to
+declare user's authorizations in the Rudder user file (rudder-users.xml).
+
+An user whose authentication is accepted by LDAP but not declared in the
+rudder-users.xml file is considered to have no rights at all (and so will
+only see a reduced version of Rudder homepage, with no action nor tabs available).
+
 If you really want to test this feature, follow this procedure:
 
 First, unzip your webapp to be able to modify some files inside it
@@ -47,33 +56,12 @@ and paste the following code block below </authentication-manager> :
      </beans:property>
    </beans:bean>
  </beans:constructor-arg>
- <beans:constructor-arg>
-   <beans:bean
-     class="org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator">
-     <beans:constructor-arg ref="contextSource"/>
-     <beans:constructor-arg value="ou=groups"/>
-     <beans:property name="groupRoleAttribute" value="ou"/>
-   </beans:bean>
- </beans:constructor-arg>
+ <beans:property name="userDetailsContextMapper" ref="rudderXMLUserRights"/>
 </beans:bean>
 
 ----
 
 You will have to adjust the ldap URI, the userDn and password to the appropriate values for your infrastructure.
-
-After that, you need to add some .jar files to the webapp classpath:
-
-----
-
-cd /opt/rudder/jetty7/webapps/rudder.war/WEB-INF/lib
-wget --user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:9.0) Gecko/20100101 Firefox/9.0" \
-http://repo2.maven.org/maven2/org/springframework/security/spring-security-ldap/3.0.5.RELEASE/spring-security-ldap-3.0.5.RELEASE.jar
-wget --user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:9.0) Gecko/20100101 Firefox/9.0" \
-http://repo2.maven.org/maven2/ldapsdk/ldapsdk/4.1/ldapsdk-4.1.jar
-wget --user-agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:9.0) Gecko/20100101 Firefox/9.0" \
-http://repo2.maven.org/maven2/org/springframework/ldap/spring-ldap-core/1.3.1.RELEASE/spring-ldap-core-1.3.1.RELEASE.jar
-
-----
 
 And you are all done !
 
@@ -83,5 +71,18 @@ And you are all done !
 
 This procedure is still hacky, we are considering several solutions to have a standardized procedure that does not require
 to touch the WAR archive and just edit some configuration files.
+
+====
+
+
+[TIP]
+
+====
+
+It is a best practice to use authenticated connection in place of anonymous one, even for application. 
+Nonetheless, if you want to use an anonymous connection to your LDAP server, you can replace the two lines
+about beans:property userDn and password in contextSource by the line:
+
+<beans:property name="anonymousReadOnly" value="true"/>
 
 ====


### PR DESCRIPTION
Update LDAP procedure to match what is needed to make User actually have rights. It relies on correction of http://www.rudder-project.org/redmine/issues/3829
