### PR TITLE
Fixes #4267: Remove useless relay documentation placeholder

### DIFF
--- a/10_install_server/30_install_relay_server.txt
+++ b/10_install_server/30_install_relay_server.txt
@@ -1,5 +1,0 @@
-// === Install Rudder Relay Server
-//
-// FIXME: This feature has not been implemented yet. 
-// Add the section in the documentation when it has been implemented.
-


### PR DESCRIPTION
Ticket: http://www.rudder-project.org/redmine/issues/4267

To be merged in 2.6 onwards
