### PR TITLE
Fixes #6503: Update command on centos is missing \"ncf-api-virtualenv\" package

### DIFF
--- a/12_upgrade/20_upgrade_centos_rhel.txt
+++ b/12_upgrade/20_upgrade_centos_rhel.txt
@@ -32,7 +32,7 @@ For Rudder Server (RHEL 6 only), upgrade the +rudder-*+ and +ncf+ packages:
 
 ----
 
-yum update "rudder-*" "ncf"
+yum update "rudder-*" "ncf*"
 
 ----
 

--- a/12_upgrade/30_upgrade_suse.txt
+++ b/12_upgrade/30_upgrade_suse.txt
@@ -35,7 +35,7 @@ For Rudder Server, upgrade all the packages associated to +rudder-server-root+:
 
 ----
 
-zypper update "rudder*" "ncf*"
+zypper update "rudder-*" "ncf*"
 
 ----
 


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/6503