### PR TITLE
Fixes #6596: Remove references to the Big Red Button in the manual

### DIFF
--- a/glossary/big-red-button.txt
+++ b/glossary/big-red-button.txt
@@ -1,8 +1,0 @@
-"Big red button":: 
-
-A button, on the right top side of every page of Rudder web interface, to
-command the emergency stop of the agents. This stop will be implicitly done in
-less than 10 minutes, or can be done immediately if the port 5309 TCP from the
-Rudder Root Server (or each relay server) is open to each nodes. This feature is
-detailed in the user documentation.
-

--- a/glossary/cf-serverd.txt
+++ b/glossary/cf-serverd.txt
@@ -1,5 +1,4 @@
 +cf-serverd+:: 
 
-This CFEngine Community daemon is listening on the network for a forced launch
-of the CFEngine Community Agent coming from the Rudder Server's Big Red Button.
-
+This CFEngine Community daemon is listening on the network on Rudder Root and Relay
+servers, serving policies and files to Rudder Nodes.


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/6596