### PR TITLE
Fixes #9621: Manual is broken because of some new syntax in ncf doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,8 @@ generic-methods.asciidoc: ncf
 	cd ncf && git checkout $(NCF_VERSION) && git pull
 	cp tools/ncf_doc_rudder.py ncf/tools/
 	./ncf/tools/ncf_doc_rudder.py
+	# Remove language setting on code field (#9621)
+	sed -i 's/```.*/```/' generic_methods.md
 	pandoc -t asciidoc -f markdown generic_methods.md > generic_methods.asciidoc
 
 $(INDEXER_JAR):


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9621