### PR TITLE
Fixes #9803: We should disable link tests for the manual on master 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,8 @@ slides.html: man $(SOURCES)
 
 test: webhelp/index.html
 	# Disable link tests on master beacause it is normal some links do not exist yet
-	[ "`git rev-parse --abbrev-ref HEAD`" == "master" ] || ./tests/check_title_syntax.sh
-	./tests/check_broken_links.sh
+	./tests/check_title_syntax.sh
+	[ "`git rev-parse --abbrev-ref HEAD`" == "master" ] || ./tests/check_broken_links.sh
 
 ## WARNING: at cleanup, delete png files that were produced by output only !
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/9803