### PR TITLE
Fixes #10548: Rudder documentation and release note don't mention the dependency to Java 1.8 for Rudder 4.1

### DIFF
--- a/10_installation/10_install_server/11_install_root_server_debian.txt
+++ b/10_installation/10_install_server/11_install_root_server_debian.txt
@@ -2,6 +2,10 @@
 
 ===== Add the Rudder packages repository
 
+Rudder 4.1 requires Java RE (version 8 at least) which is not packaged by default on Debian 7 nor Ubuntu 14.04.
+
+The Java RE 8 for Debian or Ubuntu can be found through Oracle's website: https://www.java.com
+
 include::snippets/apt_key.txt.snippet[]
 
 Then run the following commands as root:

--- a/10_installation/10_install_server/12_install_root_server_sles.txt
+++ b/10_installation/10_install_server/12_install_root_server_sles.txt
@@ -6,12 +6,12 @@
 Rudder requires three packages that are not always packaged by SuSE on all versions:
 
 * PostgreSQL 9
-* Java RE (version 7 at least).
+* Java RE (version 8 at least).
 
 PostgreSQL 9 can be installed through the OpenSuSE build service: https://build.opensuse.org/project/show/server:database:postgresql
 or through the system repositories, on post-SP1 systems.
 
-The Java RE 7 can be found either using the OpenSuSE build service, or through Oracle's website: http://www.java.com
+The Java RE 8 for SLES11 can be found through Oracle's website: https://www.java.com
 
 Also, Rudder server requires the +git+ software, that can be found on SLES SDK DVD under the name +git-core+.
 

--- a/12_upgrade/10_upgrade_debian.txt
+++ b/12_upgrade/10_upgrade_debian.txt
@@ -54,5 +54,16 @@ when apt-get/aptitude asks about this, unless you want to reset all your paramet
 
 ====
 
+[WARNING]
+
+====
+
+Rudder 4.1 requires Java RE version 8 or more, which is not packaged be default on Debian 7 nor Ubuntu 14.04
+On these platforms, prior to upgrade Rudder, you will need to install Java RE 8, either from Oracle site https://www.java.com
+or through any other means of your choice
+
+====
+
+
 You can now <<_technique_upgrade,upgrade your local techniques>>.
 

--- a/12_upgrade/30_upgrade_suse.txt
+++ b/12_upgrade/30_upgrade_suse.txt
@@ -51,6 +51,16 @@ Please look at <<install-server-sles>> for details.
 
 ====
 
+[WARNING]
+
+====
+
+Rudder 4.1 requires Java RE version 8 or more, which is not packaged be default on SLES 11
+On this platform, prior to upgrade Rudder, you will need to install Java RE 8, either from Oracle site https://www.java.com
+or through any other means of your choice
+
+====
+
 and after the upgrade of these packages, restart jetty to apply the changes on the Web application:
 
 ----


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/10548