### PR TITLE
Fixes #12569: Wrong service name in agent install instruction in 4.3

### DIFF
--- a/10_installation/11_install_agent/80_agent_configuration.txt
+++ b/10_installation/11_install_agent/80_agent_configuration.txt
@@ -24,7 +24,7 @@ You can now start the Rudder service with:
 
 ----
 
-service rudder start
+service rudder-agent start
 
 ----
 


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12569