### PR TITLE
Fixes #12594: Add a doc about generic method naming conventions

### DIFF
--- a/90_reference/55_generic_methods_best_practices.txt
+++ b/90_reference/55_generic_methods_best_practices.txt
@@ -1,0 +1,16 @@
+=== Best Practices for generic methods
+
+==== Naming convention
+
+   * A generic method should be named as this:
+       * The first part is the name of the item being defined or configured (a package, a file, a condition, etc.), the second
+         part qualifies what is being done
+       * `item_state` whenever a state name makes sense (like `package_present`)
+       * `item_subitem` when we are configuring a subitem (like `user_home`)
+       * `item_subitem_state` whenever a state name makes sense for a subitem (like `file_lines_present`)
+       * `item_from_source` whenever it is converted from something else, replacing source by the type of the source (`command`, `file`, etc.)
+       * `item_action` if it is an action (like `service_restart`)
+    * Avoid useless words, and keep things short
+    * When adding a more specific method, add a qualifier at the end
+
+


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/12594