### PR TITLE
Fixes #14415: After upgrading from 4.1.7 to 5.0.8, rudder-agent is not upgraded

### DIFF
--- a/src/reference/modules/installation/pages/upgrade.adoc
+++ b/src/reference/modules/installation/pages/upgrade.adoc
@@ -20,10 +20,14 @@ Read https://rudder.io/plugins[the plugins page on our website] for more informa
 
 [WARNING]
 ====
-When upgrading from a 4.1 older than 4.1.13, a 4.2 older than 4.2.7 or a 4.3 older than 4.3.3,
+On RHEL/centOS and SLES systems, when upgrading from a 4.1 older than 4.1.13, a 4.2 older
+than 4.2.7 or a 4.3 older than 4.3.3,
 it is necessary to explicitely upgrade `rudder-agent` (in the same command as 
 the other packages) when upgrading a relay or a root server,
 because of a dependency misconfiguration in the agent package.
+
+This has been fixed in the packages, but the problem is caused by the
+package in the version your are upgrading from.
 ====
 
 [NOTE]

--- a/src/reference/modules/installation/pages/upgrade.adoc
+++ b/src/reference/modules/installation/pages/upgrade.adoc
@@ -18,6 +18,14 @@ the plugin.
 Read https://rudder.io/plugins[the plugins page on our website] for more information.
 ====
 
+[WARNING]
+====
+When upgrading from a 4.1 older than 4.1.13, a 4.2 older than 4.2.7 or a 4.3 older than 4.3.3,
+it is necessary to explicitely upgrade `rudder-agent` (in the same command as 
+the other packages) when upgrading a relay or a root server,
+because of a dependency misconfiguration in the agent package.
+====
+
 [NOTE]
 ====
 If your Rudder server was upgraded from a 4.1 or older installation on Ubuntu 12.04 LTS or 14.04 LTS,


### PR DESCRIPTION
https://issues.rudder.io/issues/14415