### PR TITLE
Fixes #14264: uuid.hive is not present afet an install or an upgradie ofrudder agent to latest 4.1.x, 4.3.x and 5.0.x on rpm system purges the uuid.hive

### DIFF
--- a/12_upgrade/05_caution.txt
+++ b/12_upgrade/05_caution.txt
@@ -49,6 +49,25 @@ Then, you now need to use:
 
 ====
 
+[NOTE]
+
+====
+
+Upgrading from 4.1.18 or earlier can cause transient missing `/opt/rudder/etc/uuid.hive` - as this
+file is no longer part of the packaging. The issue will resolve itself, and happen only once - any
+subsequent upgrade will not exhibit this problem anymore.
+
+If you don't want to wait up to 5 minutes for this issue to correct itself, you can run:
+
+---
+rudder agent check
+---
+
+that will restore the file from backup.
+
+====
+
+
 ==== Compatibility between Rudder agent 4.1 and older server versions
 
 ===== 4.0.x servers


### PR DESCRIPTION
https://issues.rudder.io/issues/14264