### PR TITLE
Fixes #16469: Install doc mention Sles11 Rudder Server in 6.0 which is not supported

### DIFF
--- a/src/reference/modules/installation/pages/_partials/sles_repo.adoc
+++ b/src/reference/modules/installation/pages/_partials/sles_repo.adoc
@@ -16,14 +16,6 @@ zypper ar -n 'Rudder 6.0' http://repository.rudder.io/rpm/6.0/SLES_12/ Rudder
 
 ----
 
-* on SLES 11:
-
-----
-
-zypper ar -n 'Rudder 6.0' http://repository.rudder.io/rpm/6.0/SLES_11/ Rudder
-
-----
-
 Update your local package database to retrieve the list of packages available on our repository:
 
 ----


### PR DESCRIPTION
https://issues.rudder.io/issues/16469