### PR TITLE
Fixes #17484: wrong url to download.rudder.io on 6.1

### DIFF
--- a/src/reference/modules/installation/pages/_partials/debian_repo.adoc
+++ b/src/reference/modules/installation/pages/_partials/debian_repo.adoc
@@ -21,7 +21,7 @@ the user name and the password by your Rudder account):
 [source, Bash]
 ----
 
-echo "deb https://LOGIN:PASSWORD@download.rudder.io/apt/6.0/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/rudder.list
+echo "deb https://LOGIN:PASSWORD@download.rudder.io/apt/6.1/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/rudder.list
 
 ----
 

--- a/src/reference/modules/installation/pages/_partials/sles_repo.adoc
+++ b/src/reference/modules/installation/pages/_partials/sles_repo.adoc
@@ -16,7 +16,7 @@ the user name and the password by your Rudder account):
 
 ----
 
-zypper ar -n 'Rudder 6.0' http://LOGIN:PASSWORD@download.rudder.io/rpm/6.0/SLES_15/ Rudder
+zypper ar -n 'Rudder 6.1' http://LOGIN:PASSWORD@download.rudder.io/rpm/6.1/SLES_15/ Rudder
 
 ----
 
@@ -38,7 +38,7 @@ the user name and the password by your Rudder account):
 
 ----
 
-zypper ar -n 'Rudder 6.0' http://LOGIN:PASSWORD@download.rudder.io/rpm/6.0/SLES_12/ Rudder
+zypper ar -n 'Rudder 6.1' http://LOGIN:PASSWORD@download.rudder.io/rpm/6.1/SLES_12/ Rudder
 
 ----
 


### PR DESCRIPTION
https://issues.rudder.io/issues/17484