### PR TITLE
Fixes #19761: Document that a "rudder agent server-keys-reset" is necessary to move a node to another policy server

### DIFF
--- a/src/reference/modules/installation/pages/_partials/relay_initial_config.adoc
+++ b/src/reference/modules/installation/pages/_partials/relay_initial_config.adoc
@@ -43,11 +43,12 @@ You then have two possible cases:
 The procedure on both cases is the same, you have to:
 
 - Update the policy server with the IP address or the fully qualified domain name of the relay server
-(instead of the root server)
+(instead of the root server) and reset pinned public key
 
 ----
 
 rudder agent policy-server <rudder relay ip or hostname>                                                     
+rudder agent server-keys-reset
 
 ----
 


### PR DESCRIPTION
https://issues.rudder.io/issues/19761