### PR TITLE
Fixes #19919: Document that escaping is incoherent with the rest in Technique Editor in 6.X, that it is corrected in 7.0, and that's a breaking change

### DIFF
--- a/src/reference/modules/usage/pages/configuration_management.adoc
+++ b/src/reference/modules/usage/pages/configuration_management.adoc
@@ -102,7 +102,7 @@ image::Rule_config.png[]
 [[Variables-and-values]]
 == Variables and Values
 
-Values used in Directives, Parameters and Properties have several types - Parameters and Properties are either String or JSON, while in Directives they can be free String, String validated by regular expression, or Javascript.
+Values used in directives, parameters and properties have several types - parameters and properties are either String or JSON, while in directives they can be free String, String validated by regular expression, or Javascript.
 
 These values are automatically escaped to be managed correctly. The escaping doubles the backslashes ( `\` -> `\\` ), and replace a quote by a backslash quote ( `"` -> `\\"`) on Linux/Unix systems, and on Windows it replaces a quote by a backtick quote ( `` " `` -> `` `" `` ), and doubles the backticks.
 
@@ -112,7 +112,9 @@ These values are automatically escaped to be managed correctly. The escaping dou
 
 Values in the Technique Editor in Rudder 6.X are *not* escaped - their content need to be escaped, based on the previous rules. Starting in Rudder 7.0, values in Technique Editor are escaped properly.
 
-Prior to upgrading from 6.X to 7.0, you need to review values in Techniques from the Technique Editor to unescape ", \ and ` 
+
+Prior to upgrading from 6.X to 7.0, you need to review values in Techniques from the Technique Editor to detect any unescaped ", \ and `
+Safest approach is to disable these Techniques for the upgrade, and unescape the values and enable back the Techniques once upgrade to 7.0 is done 
 
 ====
 

--- a/src/reference/modules/usage/pages/configuration_management.adoc
+++ b/src/reference/modules/usage/pages/configuration_management.adoc
@@ -110,7 +110,7 @@ These values are automatically escaped to be managed correctly. The escaping dou
 
 ====
 
-Values in the Technique Editor in Rudder 6.X are *not* escaped - their content need to be escaped, based on the previous rules. Starting in Rudder 7.0, values in Technique Editor are escaped properly.
+Values in the Technique Editor in Rudder 6.X are *not* escaped - their content needs to be escaped, based on the previous rules. Starting in Rudder 7.0, values in Technique Editor are escaped properly.
 
 
 Prior to upgrading from 6.X to 7.0, you need to review values in Techniques from the Technique Editor to detect any unescaped ", \ and `

--- a/src/reference/modules/usage/pages/configuration_management.adoc
+++ b/src/reference/modules/usage/pages/configuration_management.adoc
@@ -99,7 +99,23 @@ if you feel the generated policies should be modified (for instance, if you chan
 
 image::Rule_config.png[]
 
-== Variables
+[[Variables-and-values]]
+== Variables and Values
+
+Values used in Directives, Parameters and Properties have several types - Parameters and Properties are either String or JSON, while in Directives they can be free String, String validated by regular expression, or Javascript.
+
+These values are automatically escaped to be managed correctly. The escaping doubles the backslashes ( `\` -> `\\` ), and replace a quote by a backslash quote ( `"` -> `\\"`) on Linux/Unix systems, and on Windows it replaces a quote by a backtick quote ( `` " `` -> `` `" `` ), and doubles the backticks.
+
+[WARNING]
+
+====
+
+Values in the Technique Editor in Rudder 6.X are *not* escaped - their content need to be escaped, based on the previous rules. Starting in Rudder 7.0, values in Technique Editor are escaped properly.
+
+Prior to upgrading from 6.X to 7.0, you need to review values in Techniques from the Technique Editor to unescape ", \ and ` 
+
+====
+
 
 Rudder provides multiple ways to add common and reusable variables in either plain directives, or techniques created using the technique editor.
 See xref:usage:variables.adoc[Variables] for more details.


### PR DESCRIPTION
https://issues.rudder.io/issues/19919