### PR TITLE
Fixes #22046: Windows agent exe link in install doc does not point to the right folder

### DIFF
--- a/src/reference/modules/installation/pages/agent/windows.adoc
+++ b/src/reference/modules/installation/pages/agent/windows.adoc
@@ -4,7 +4,7 @@
 
 ====
 
-Windows agents are only available with a subscription and can be downloaded on https://download.rudder.io.
+Windows agents are only available with a subscription and can be downloaded on https://download.rudder.io/misc/windows/.
 
 ====
 


### PR DESCRIPTION
https://issues.rudder.io/issues/22046