### PR TITLE
Fixes #22621: Documentation on how to upgrade Rudder to 7.2 is invalid on zypper

### DIFF
--- a/src/reference/modules/installation/pages/upgrade/sles.adoc
+++ b/src/reference/modules/installation/pages/upgrade/sles.adoc
@@ -25,7 +25,7 @@ For Rudder server, upgrade the server packages:
 
 ----
 
-zypper update rudder-server
+zypper install rudder-server
 
 ----
 


### PR DESCRIPTION
https://issues.rudder.io/issues/22621