### PR TITLE
Fixes #22737: Installation documentation should use ' instead of " to avoid unwanted bash string interpretation

### DIFF
--- a/src/reference/modules/installation/pages/_partials/debian_repo.adoc
+++ b/src/reference/modules/installation/pages/_partials/debian_repo.adoc
@@ -24,11 +24,11 @@ You need to replace the user name (LOGIN) and the password (PASSWORD) by your Ru
 echo "deb https://download.rudder.io/apt/7.2/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/rudder.list
 
 # for recent debian (>=10) and ubuntu (>=20)
-echo "machine download.rudder.io login LOGIN password PASSWORD" > /etc/apt/auth.conf.d/rudder.conf
+echo 'machine download.rudder.io login LOGIN password PASSWORD' > /etc/apt/auth.conf.d/rudder.conf
 chmod 640 /etc/apt/auth.conf.d/rudder.conf
 
 # on old debian (<10) and ubuntu (<20) use this instead
-#echo "machine download.rudder.io login LOGIN password PASSWORD" >> /etc/apt/auth.conf
+#echo 'machine download.rudder.io login LOGIN password PASSWORD' >> /etc/apt/auth.conf
 #chmod 640 /etc/apt/auth.conf
 
 ----

--- a/src/reference/modules/installation/pages/_partials/debian_repo_new.adoc
+++ b/src/reference/modules/installation/pages/_partials/debian_repo_new.adoc
@@ -23,7 +23,7 @@ You need to replace the user name (LOGIN) and the password (PASSWORD) by your Ru
 
 echo "deb https://download.rudder.io/apt/7.2/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/rudder.list
 
-echo "machine download.rudder.io login LOGIN password PASSWORD" > /etc/apt/auth.conf.d/rudder.conf
+echo 'machine download.rudder.io login LOGIN password PASSWORD' > /etc/apt/auth.conf.d/rudder.conf
 chmod 640 /etc/apt/auth.conf.d/rudder.conf
 
 ----


### PR DESCRIPTION
https://issues.rudder.io/issues/22737