### PR TITLE
Fixes #22767: proxy documentation is lost in rudder 7.3 documentation

### DIFF
--- a/src/reference/modules/installation/pages/agent/windows.adoc
+++ b/src/reference/modules/installation/pages/agent/windows.adoc
@@ -63,7 +63,29 @@ The policy server configuration can be provisionned prior to the installation by
 ----
 C:\Program Files\Rudder\etc\policy-server.conf
 ----
-Proxy options for the agent can be pre-configured if needed, see the https://docs.rudder.io/reference/7.3/plugins/windows.html#_proxy_settings[dedicated documentation].
+
+Proxy options for the agent can be pre-configured if needed, see next section.
+
+== Proxy settings
+
+Agent supports configuration through proxy. Proxy can be configured in the file `C:\Program Files\Rudder\etc\agent.conf` which exists by default.
+It is a key-value based file, currently only supporting the `https_proxy` option.
+
+Correct value formats for the `https_proxy` key are listed below:
+
+----
+https_proxy =
+
+https_proxy = "192.168.2.4"
+
+https_proxy = "192.168.2.4:3128"
+
+# For authenticated proxy
+https_proxy = "user:password@192.168.2.4:3128"
+
+# To use the system defined proxy
+https_proxy = "system"
+----
 
 == Logs
 


### PR DESCRIPTION
https://issues.rudder.io/issues/22767