### PR TITLE
Fixes #22778: Missing documentation for AmazonLinux 2023 install for the agent

### DIFF
--- a/src/reference/modules/installation/nav.adoc.src
+++ b/src/reference/modules/installation/nav.adoc.src
@@ -14,7 +14,7 @@
 ** Install server
 *** xref:server/debian.adoc[on Debian/Ubuntu]
 *** xref:server/rhel.adoc[on RHEL/CentOS/AL2023]
-*** xref:server/al2.adoc[on Amazon Linux 2]
+*** xref:server/al.adoc[on Amazon Linux]
 *** xref:server/sles.adoc[on SLES]
 *** xref:server/external-db.adoc[with a separate DB]
 ** Install agent

--- a/src/reference/modules/installation/pages/_partials/al2023_repo.adoc
+++ b/src/reference/modules/installation/pages/_partials/al2023_repo.adoc
@@ -1,0 +1,31 @@
+Add a yum repository for Rudder:
+
+----
+
+echo '[Rudder_7.3]
+name=Rudder 7.3
+baseurl=http://repository.rudder.io/rpm/7.3/AL_2023/
+gpgcheck=1
+gpgkey=https://repository.rudder.io/rpm/rudder_rpm_key.pub' > /etc/yum.repos.d/rudder.repo
+
+----
+
+[NOTE]
+====
+
+If you have an active subscription, use the following to get access to long term support (you need to replace
+the user name and the password by your Rudder account):
+
+----
+
+echo '[Rudder_7.3]
+name=Rudder 7.3
+username=LOGIN
+password=PASSWORD
+baseurl=http://download.rudder.io/rpm/7.3/AL_2023/
+gpgcheck=1
+gpgkey=https://download.rudder.io/rpm/rudder_rpm_key.pub' > /etc/yum.repos.d/rudder.repo
+
+----
+
+====

--- a/src/reference/modules/installation/pages/agent/rhel.adoc
+++ b/src/reference/modules/installation/pages/agent/rhel.adoc
@@ -30,6 +30,18 @@ gpgkey=https://repository.rudder.io/rpm/rudder_rpm_key.pub' > /etc/yum.repos.d/r
 
 ----
 
+* on Amazon Linux 2023:
+
+----
+
+echo '[Rudder_7.3]
+name=Rudder 7.3
+baseurl=http://repository.rudder.io/rpm/7.3/AL_2023/
+gpgcheck=1
+gpgkey=https://repository.rudder.io/rpm/rudder_rpm_key.pub' > /etc/yum.repos.d/rudder.repo
+
+----
+
 Install the package:
 
 ----

--- a/src/reference/modules/installation/pages/index.adoc
+++ b/src/reference/modules/installation/pages/index.adoc
@@ -8,7 +8,7 @@ separated environments where each environment requires its own server.
 
 Installation instructions:
 
-* Install a Rudder server on: xref:installation:server/debian.adoc[Debian/Ubuntu] | xref:installation:server/rhel.adoc[RHEL/CentOS] | xref:installation:server/sles.adoc[SLES] | xref:installation:server/al2.adoc[Amazon Linux 2]
+* Install a Rudder server on: xref:installation:server/debian.adoc[Debian/Ubuntu] | xref:installation:server/rhel.adoc[RHEL/CentOS] | xref:installation:server/sles.adoc[SLES] | xref:installation:server/al.adoc[Amazon Linux]
 
 * Upgrade a Rudder server on: xref:upgrade:server/debian.adoc[Debian/Ubuntu] | xref:upgrade:server/rhel.adoc[RHEL/CentOS] | xref:upgrade:server/sles.adoc[SLES]
 

--- a/src/reference/modules/installation/pages/server/al.adoc
+++ b/src/reference/modules/installation/pages/server/al.adoc
@@ -1,4 +1,28 @@
-= Install Rudder root server on Amazon Linux 2
+= Install Rudder root server
+
+== on Amazon Linux 2023
+
+include::{partialsdir}/quick_server.adoc[]
+
+include::{partialsdir}/server_notes.adoc[]
+
+include::{partialsdir}/rpm_key.adoc[]
+
+include::{partialsdir}/rhel_repo.adoc[]
+
+To begin the installation, you should simply install the rudder-server
+metapackage, which will install the required components:
+
+----
+
+yum install rudder-server
+
+----
+
+include::{partialsdir}/initial_config.adoc[]
+
+
+== on Amazon Linux 2
 
 To install a Rudder Server on Amazon Linux 2, you need a subscription and access to the private repositories.
 

--- a/src/reference/modules/installation/pages/server/external-db.adoc
+++ b/src/reference/modules/installation/pages/server/external-db.adoc
@@ -131,5 +131,5 @@ DB_NAME="rudder"
 
 === Install Rudder
 
-Finally follow the regular Rudder server installation process depending on your system: xref:installation:server/debian.adoc[Debian/Ubuntu] | xref:installation:server/rhel.adoc[RHEL/CentOS] | xref:installation:server/sles.adoc[SLES] | xref:installation:server/al2.adoc[Amazon Linux 2]
+Finally follow the regular Rudder server installation process depending on your system: xref:installation:server/debian.adoc[Debian/Ubuntu] | xref:installation:server/rhel.adoc[RHEL/CentOS] | xref:installation:server/sles.adoc[SLES] | xref:installation:server/al.adoc[Amazon Linux]
 


### PR DESCRIPTION
https://issues.rudder.io/issues/22778