### PR TITLE
Fixes #23644: Broken links in docs homepage - 8.0

### DIFF
--- a/src/get-started/modules/ROOT/pages/home.adoc
+++ b/src/get-started/modules/ROOT/pages/home.adoc
@@ -1,19 +1,19 @@
 = Welcome to Rudder Documentation
 
 * Discover Rudder
-** xref:7.3@reference:ROOT:index.adoc[What is Rudder]Discover Rudder features and use cases
+** xref:8.0@reference:ROOT:index.adoc[What is Rudder]Discover Rudder features and use cases
 ** https://demo.rudder.io[Online demo]Explore the Web interface with an online demo
 ** xref:index.adoc[Get started guide]Get started with Rudder on a test platform
 
 * Install Rudder
-** xref:7.3@reference:installation:requirements.adoc[Requirements]Requirement for Rudder installation
+** xref:8.0@reference:installation:requirements.adoc[Requirements]Requirement for Rudder installation
 //** Install a Rudder root server to define your configuration policies on xref:reference:installation:server/debian.adoc[Debian/Ubuntu], xref:reference:installation:server/rhel.adoc[RHEL/CentOS] or xref:reference:installation:server/sles.adoc[SLES]
-** xref:7.3@reference:installation:server/debian.adoc[Install Rudder server]Install a Rudder root server to define your configuration policies
+** xref:8.0@reference:installation:server/debian.adoc[Install Rudder server]Install a Rudder root server to define your configuration policies
 //** Install a Rudder agent to apply configuration on xref:reference:installation:agent/debian.adoc[Debian/Ubuntu], xref:reference:installation:agent/rhel.adoc[RHEL/CentOS] or xref:reference:installation:agent/sles.adoc[SLES]
-** xref:7.3@reference:installation:agent/debian.adoc[Install Rudder agent]Install a Rudder agent to apply configuration
+** xref:8.0@reference:installation:agent/debian.adoc[Install Rudder agent]Install a Rudder agent to apply configuration
 
 * Use Rudder
-** xref:7.3@reference:ROOT:index.adoc[User manual]Reference documentation
+** xref:8.0@reference:ROOT:index.adoc[User manual]Reference documentation
 ** https://docs.rudder.io/api[API reference]To automate actions and extract information
 ** xref:rudder-by-example:ROOT:index.adoc[Rudder by example]for real and detailed use-case examples
 


### PR DESCRIPTION
https://issues.rudder.io/issues/23644