### PR TITLE
Fixes #23680: 8.0 documentation of supported rudder-server OS is outdated

### DIFF
--- a/src/reference/modules/installation/pages/operating_systems.adoc
+++ b/src/reference/modules/installation/pages/operating_systems.adoc
@@ -90,7 +90,7 @@ The following operating systems are supported as a Rudder relay or server:
 | OS | Version | Architecture
 
 | Debian | 11 and 12 | 64bit
-| Ubuntu | 20.04 LTS and 22.04 LTS | 64bit
+| Ubuntu | 22.04 LTS | 64bit
 | Red Hat Enterprise Linux (RHEL) / AlmaLinux, Rocky Linux, Oracle Linux / CentOS Stream | 8 and 9 | 64bit
 | SUSE Linux Enterprise Server (SLES) | 15 SP4+ | 64bit
 | Amazon Linux | 2023 | 64bit


### PR DESCRIPTION
https://issues.rudder.io/issues/23680