### PR TITLE
Fixes #23312: Import key section in AIX agent install doc is empty

### DIFF
--- a/src/reference/modules/installation/pages/agent/aix.adoc
+++ b/src/reference/modules/installation/pages/agent/aix.adoc
@@ -8,8 +8,6 @@ are also compatible with AIX.
 
 ====
 
-== Import key
-
 include::{partialsdir}/rpm_key.adoc[]
 
 == With yum


### PR DESCRIPTION
https://issues.rudder.io/issues/23312