### PR TITLE
Fixes #25074: Remove supported os for Ubuntu 24.04 for server and relay in 8.0

### DIFF
--- a/src/reference/modules/installation/pages/operating_systems.adoc
+++ b/src/reference/modules/installation/pages/operating_systems.adoc
@@ -105,7 +105,7 @@ The following operating systems are supported as a Rudder relay or server:
 | OS | Version | Architecture
 
 | Debian | 11 and 12 | 64bit
-| Ubuntu | 22.04 LTS and 24.04 LTS | 64bit
+| Ubuntu | 22.04 LTS | 64bit
 | Red Hat Enterprise Linux (RHEL) / AlmaLinux, Rocky Linux, Oracle Linux / CentOS Stream | 8 and 9 | 64bit
 | SUSE Linux Enterprise Server (SLES) | 15 SP4+ | 64bit
 | Amazon Linux | 2023 | 64bit


### PR DESCRIPTION
https://issues.rudder.io/issues/25074
Introduced by https://github.com/Normation/rudder-doc/pull/1038