### PR TITLE
Fixes #25726: Property name case collision is not longer a thing on Windows node since 8.2

### DIFF
--- a/src/reference/modules/installation/pages/agent/windows.adoc
+++ b/src/reference/modules/installation/pages/agent/windows.adoc
@@ -17,15 +17,6 @@ how to install a plugin https://docs.rudder.io/reference/8.0/plugins/index.html#
 
 ====
 
-[WARNING]
-
-====
-
-Note that even if properties' name is case-sensitive, collision can occur, on nodes based on Windows agent.
-We strongly recommend to use distinct strings for property's name, in particular on Windows node.
-
-====
-
 == Installation for Windows server 2012R2 and later
 
 The agent is currently distributed as an `msi` installer which both support graphical and cli based installations.

--- a/src/reference/modules/reference/pages/variables.adoc
+++ b/src/reference/modules/reference/pages/variables.adoc
@@ -52,16 +52,6 @@ example:
 ${node.properties[datacenter]}
 ----
 
-
-[WARNING]
-
-====
-
-Note that even if properties' name is case-sensitive, collision can occur, on nodes based on Windows agent.
-We strongly recommend to use distinct strings for property's name, in particular on Windows node.
-
-====
-
 To get the original data (for debug only) there is the
 `properties.property_<fileid>` variable. A usage example:
 


### PR DESCRIPTION
https://issues.rudder.io/issues/25726
I'm not able to pinpoint was exactly changed in the code as proof, but if you need more details, ask @Fdall