### PR TITLE
Fixes #28233: Missleading documentation about parameter maximum size of file uploads on the server

### DIFF
--- a/src/reference/modules/administration/pages/webapp.adoc
+++ b/src/reference/modules/administration/pages/webapp.adoc
@@ -73,6 +73,14 @@ Or for the maximum number of keys in HTTP forms:
 
 Then restart the application with `systemctl restart rudder-jetty` for these settings to take effect.
 
+[NOTE]
+===
+For this example, bear in mind that there is a always a limit to file size upload,
+the webapp itself has a hard limit of 8MB by default,
+starting from which which you may use xref:administration:relayd.adoc#_data_files[the shared folder] 
+or xref:usage:technique_editor.adoc#_interface[technique resources].
+===
+
 == Data files
 
 The webapp is loaded from `/opt/rudder/share/webapp/rudder.war`.

--- a/src/reference/modules/reference/pages/jetty_server_configuration.adoc
+++ b/src/reference/modules/reference/pages/jetty_server_configuration.adoc
@@ -64,13 +64,21 @@ configuration (files name, ...), etc.
 You can also override system properties that need to be passed to java command line
 with `-D` option in that file. Typically, if you need to increase `maxFormContentSize`
 or `maxFormKey` as explained
-https://www.eclipse.org/jetty/documentation/current/configuring-form-size.html[in Jetty documentation],
+https://jetty.org/docs/jetty/12.1/programming-guide/security/configuring-form-size.html[in Jetty documentation]
 you can just add corresponding lines at the end of `start.ini`:
 
 ----
 -Dorg.eclipse.jetty.server.Request.maxFormKeys=200
 -Dorg.eclipse.jetty.server.Request.maxFormContentSize=400000
 ----
+
+[NOTE]
+===
+For this example, bear in mind that there is a always a limit to file size upload,
+the webapp itself has a hard limit of 8MB by default,
+starting from which which you may use xref:administration:relayd.adoc#_data_files[the shared folder] 
+or xref:usage:technique_editor.adoc#_interface[technique resources].
+===
 
 == Other Jetty places
 


### PR DESCRIPTION
https://issues.rudder.io/issues/28233

Same as https://github.com/Normation/rudder-doc/pull/1147 (backport), just without the change in `start.ini` VS `start.d/` 