### PR TITLE
Fixes #29473: PostgreSQL documentation is incorrect wrt to current support version

### DIFF
--- a/src/reference/modules/administration/pages/performance.adoc
+++ b/src/reference/modules/administration/pages/performance.adoc
@@ -17,18 +17,30 @@ with little available disk space, this may be problematic.
 There are two strategies, that can be combined, to lower the requirement on disk usage.
 
 First, you can lower the retention duration for reports from nodes, by setting in file
-`/opt/rudder/etc/rudder-web.properties` the options:
+`/opt/rudder/etc/rudder-web.properties` the option:
 
-* `rudder.batch.reportscleaner.archive.TTL=0`
 * `rudder.batch.reportscleaner.delete.TTL=3`
+
+A related option, `rudder.batch.reportsCleaner.deleteLogReport.TTL`, controls how long the log
+reports (extra debugging information sent by the agents, not used for compliance) are kept. It is
+expressed either in minutes, or as a number of agent runs with the `Nx` notation. Its default value
+of `2x` (twice the longest agent run interval) is appropriate in most cases and does not usually
+need to be changed.
+
+[NOTE]
+
+====
+
+Lowering the retention duration frees space *inside* the database files, which is then reused by
+the new reports sent by the nodes. It does **not** return that space to the filesystem: the
+size of the PostgreSQL data directory will not decrease. If you need to actually reclaim the
+disk space after lowering the retention, see
+xref:administration:procedures.adoc#_postgresql_database_bloating[PostgreSQL database bloating].
+
+====
 
 Second possibility is to make the agents send less reports to the Rudder server, by switching to `Non compliance only` compliance reporting mode. In this mode, only reports of changes or errors will be sent to the Rudder server. This mode saves a lot of log space and bandwidth, but leads to some assumptions about actual configuration status in reporting.
 This can be configured in the Settings/General page, section `Compliance reporting mode`
-
-Finally, compliance levels are also historized over time; disabling their saving also save disk space:
-`/opt/rudder/etc/rudder-web.properties`:
-
-* `rudder.batch.reportscleaner.compliancelevels.delete.TTL=0`
 
 == Apache web server
 
@@ -150,7 +162,7 @@ JETTY_START_TIMEOUT=360
 == Make better use of resources
 
 Most operations can be parallelized within Rudder, to take most advantage of the available resources.
-These parameters can be set through the https://docs.rudder.io/api/v/13/#operation/getAllSettings[setting API]
+These parameters can be set through the https://docs.rudder.io/api/v/22/#operation/getAllSettings[setting API]
 Most notable settings, with recommended values are:
 
 [cols="<.^2,<.^2,<.^1,<.^3", options="header"]
@@ -160,9 +172,8 @@ Most notable settings, with recommended values are:
 |rudder_compute_dyngroups_max_parallelism|1|4|1
 |rudder_generation_delay|"0 seconds"|5 seconds|10 seconds
 |rudder_report_protocol_default|HTTPS|HTTPS|HTTPS
-|reporting_mode|full-compliance|`recommended value depends on your needs`|changes-only
+|rudder_compliance_mode|full-compliance|`recommended value depends on your needs`|changes-only
 |rudder_compute_changes|true|true|false
-|rudder_save_db_compliance_levels|true|false|false
 |=======================
 
 Note: x0.5 means half the number of available CPUs
@@ -229,13 +240,6 @@ max_stack_depth = 4MB
 
 maintenance_work_mem = 2GB
 
-# Write ahead log
-# ---------------
-#
-# Size of the write ahead log:
-
-wal_buffers = 4MB
-
 
 ----
 
@@ -246,10 +250,33 @@ wal_buffers = 4MB
 shared_buffers = 256MB
 work_mem = 4MB
 maintenance_work_mem = 256MB
-wal_buffers = 1MB
 
 
 ----
+
+[NOTE]
+
+====
+
+Do not set `wal_buffers` manually. Since PostgreSQL 9.1, its default value (`-1`) makes PostgreSQL
+derive it from `shared_buffers` (1/32 of it, capped at 16MB), which is the appropriate value for
+Rudder's write pattern. Setting it explicitly to a smaller value can only degrade performance.
+
+Earlier versions of this documentation suggested setting `wal_buffers` to `4MB` (large instances) or
+`1MB` (standard instances). These are respectively 4 and 8 times *smaller* than the values
+PostgreSQL derives from the `shared_buffers` suggested above. If you applied that advice, remove the
+`wal_buffers` line from your `postgresql.conf` and restart PostgreSQL, as this parameter can only be
+changed at server start:
+
+----
+
+# The name of the service may vary if you installed
+# non-standard postgresql packages
+systemctl restart postgresql
+
+----
+
+====
 
 ==== Maximum number of file descriptors
 

--- a/src/reference/modules/administration/pages/procedures.adoc
+++ b/src/reference/modules/administration/pages/procedures.adoc
@@ -20,7 +20,6 @@ database.
 By default, this system will:
 
 * Remove reports older than 4 days
-* Delete all historized compliance levels after 15 days
 * Delete logs older than twice the maximum agent run interval
 
 Logs are extra information on agent runs, that are used for debugging purpose, and are not
@@ -31,38 +30,58 @@ and putting aside old ones.
 This is configurable in `/opt/rudder/etc/rudder-web.properties`, by changing the following
 configuration elements:
 
-* `rudder.batch.reportscleaner.archive.TTL`: Set the maximum report age before archival (in days)
 * `rudder.batch.reportscleaner.delete.TTL`: Set the maximum report age before deletion  (in days)
-* `rudder.batch.reportscleaner.compliancelevels.delete.TTL` : Set the maximum compliance age before removal  (in days)
 * `rudder.batch.reportsCleaner.deleteLogReport.TTL` : Set the maximum retention of logs reports, (in runs number, using Nx notation, e.g. 2x for two runs, or in minutes)
 
 The default values are OK for systems under moderate load, and should be adjusted in case of
 excessive database bloating (see next section).
 
-The estimated disk space consumption, with a 5 minutes agent run frequency, is 500 to 900 kB per Directive,
-per day and per node, plus 150 kB per Directive per node per day for archived reports, plus 150 kB per Directive per node per day for compliance level,
-which equate to is roughly 5 to 7 MB per Directive per two weeks and per node.
+The estimated disk space consumption, with a 5 minutes agent run frequency, is 500 to 900 kB per
+Directive, per day and per node. With the default retention of 4 days, that is roughly 2 to 3.6 MB
+per Directive and per node. The volume is proportional to the number of agent runs, so it scales
+inversely with the agent run interval: with a 1 hour run interval, divide these figures by 12.
 
-Thus, 25 directives on 100 nodes, with the default reports retention policy, would take 4 to 6 GB, and
+Thus, 25 directives on 100 nodes, with the default reports retention policy, would take 5 to 9 GB, and
 25 directives on 1000 nodes with a 1 hour agent execution period with the default reports retention policy
-would take 5 to 8 GB.
+would take 4 to 8 GB.
 
+[[_postgresql_database_bloating]]
 === PostgreSQL database bloating
 
 PostgreSQL database can grow over time, even if the number of nodes and directives remain the same.
 This is because even if the database is regularly cleaned by Rudder as requested,
 the physical storage backend does not reclaim space on the hard drive, resulting in a "fragmented" database.
 
-This is often not an issue, as recent versions of PostgreSQL handle this correctly,
-and new reports sent by the nodes to Rudder should fill the blanks in the database.
-This task is handled by the auto-vacuum process, which periodically cleans the storage regularly
-to prevent database bloating.
+In steady state this is often not an issue: the space freed inside the database files is reused by
+the new reports sent by the nodes. Making that space reusable is the job of the `VACUUM` process,
+which runs both automatically (PostgreSQL's autovacuum) and explicitly (Rudder vacuums the report
+tables after each database cleaning).
 
-However, in very rare occasions, the database may grow significantly, resulting in large disk usage, and slower performance, due to massive
-bloating (with database 3 or 4 times larger than necessary).
+`VACUUM` does not, however, return the freed space to the filesystem: the size of the PostgreSQL
+data directory does not decrease. In particular, lowering the report retention duration frees
+space inside the files, but does not give it back to the operating system.
+
+The database may also grow beyond its steady-state size, resulting in large disk usage and slower
+performance, due to bloating (with database 3 or 4 times larger than necessary). This happens when
+`VACUUM` cannot keep up with the rate of change.
 
 To cure (or prevent) this behavior, you can trigger vacuum full operations, which put an exclusive lock on tables,
 and will lock both the Rudder interface and the reporting system for quite a long time.
+
+[WARNING]
+
+====
+
+`VACUUM FULL` rewrites the whole table into new files before removing the old ones, so it needs
+free disk space at least equal to the size of the table being processed (plus its indexes). Check
+the available space before starting, in particular if you are running it *because* the partition is
+already close to full. You can get the size of the report table with:
+
+----
+rudder# SELECT pg_size_pretty(pg_total_relation_size('ruddersysevents'));
+----
+
+====
 
 ==== Reclaiming space with locking, using VACUUM FULL
 
@@ -78,11 +97,10 @@ and will lock both the Rudder interface and the reporting system for quite a lon
 sudo -u postgres psql -d rudder
 
 # With rudder credentials, it will ask the password in this case:
-psql -u rudder -d rudder
+psql -U rudder -d rudder -h localhost
 
 # And then, when you are connected to the rudder database in the psql shell, trigger a vacuum:
 rudder# VACUUM FULL ruddersysevents;
-rudder# VACUUM FULL archivedruddersysevents;
 ----
 
 

--- a/src/reference/modules/installation/pages/requirements.adoc
+++ b/src/reference/modules/installation/pages/requirements.adoc
@@ -53,7 +53,9 @@ dedicated support.
 
 == PostgreSQL
 
-We ensure that the version of PostgreSQL provided by all supported OS is compatible with Rudder. 
+Rudder requires *PostgreSQL 13 or later*.
+
+We ensure that the version of PostgreSQL provided by all supported OS is compatible with Rudder.
 If you want to use an external database, please check specific requirements in the setup documentation for installing xref:server/external-db.adoc#install-postgresql[the PostgreSQL server] on a separate host.
 
 [[rudder-cloud-compatibility]]
@@ -150,23 +152,25 @@ To manage more than 100 nodes, it is strongly recommended to use SSD or NAS/SAN 
 
 The PostgreSQL database will take up most of the disk space needed by Rudder. The storage
 necessary for the database can be estimated by counting around
-500 to 900 kB per Directive per Node per Day of retention of node execution reports (default is 4 days),
-plus 150 kB per Directive per Node per Day of archiving (default is 0 days),
-plus 150 kB per Directive per Node per Day of compliance retention (default is 8 days) :
+500 to 900 kB per Directive per Node per Day of retention of node execution reports
+(default is 4 days), assuming the default 5 minutes agent run interval:
 
 ----
-max_space = number of Directives * number of Nodes * ( retention duration in days * 900 kB + archive retention in days * 150 + compliance retention in days * 150 )
+max_space = number of Directives * number of Nodes * retention duration in days * 900 kB
 ----
 
 For example, a default installation with 500 nodes and an average of
-50 Directives by node should require between *76 GB and 114 GB* of disk space
+50 Directives by node should require between *50 GB and 90 GB* of disk space
 for PostgreSQL.
+
+The volume is proportional to the number of agent runs, so it scales inversely with the agent run
+interval: with a 1 hour run interval instead of 5 minutes, divide the result by 12.
 
 If you use the Policy Benchmarks plugin, the amount of data reported by the nodes is significantly higher, and as a rule of thumb, you can consider that it add the equivalent of 25 extra Directives
 The computation for disk usage for PostgreSQL database becomes:
 
 ----
-max_space_with_policy_benchmarks = (number of Directives + 25 ) * number of Nodes * ( retention duration in days * 900 kB + archive retention in days * 150 + compliance retention in days * 150 )
+max_space_with_policy_benchmarks = (number of Directives + 25 ) * number of Nodes * retention duration in days * 900 kB
 ----
 
 Follow the xref:administration:performance.adoc#_reports_retention[reports Retention] section to configure the

--- a/src/reference/modules/installation/pages/upgrade/postgresql.adoc
+++ b/src/reference/modules/installation/pages/upgrade/postgresql.adoc
@@ -32,7 +32,8 @@ Also, we strongly recommend you to have a *database backup before trying to upgr
 
 First, make sure you have the right version installed for the Rudder version you want to upgrade to.
 
-Rudder 8.0 requires at least PostgreSQL 13.
+Rudder requires at least PostgreSQL 13, see
+xref:installation:requirements.adoc#_postgresql[the requirements].
 
 On Debian-like systems:
 


### PR DESCRIPTION
https://issues.rudder.io/issues/29473

Several statements about PostgreSQL retention and disk usage no longer match the code, some since 8.2. Remove or correct them.
    
# Retention (performance.adoc, procedures.adoc):
    
- `reportscleaner.archive.TTL` was documented as a disk usage lever, but archiving no longer exists: the archived* tables were dropped in 8.2 and no code path archives anything.
- Likewise `reportscleaner.compliancelevels.delete.TTL`: compliance levels are not historized any more (nodecompliancelevels was dropped) and `DatabaseManagerImpl.deleteEntries` ignores its complianceLevels argument, so setting it saves nothing.
- Mention `reportsCleaner.deleteLogReport.TTL`, which was documented nowhere on the performance page.
- Add a note that lowering the retention frees space inside the database files but does not return it to the filesystem, with a link to the procedure that does.
    
# Sizing (procedures.adoc, requirements.adoc):
    
- The disk usage formula still added an archive term and a compliance level term, the latter with a non-zero default, so it systematically overestimated: ~30 GB of the 76-114 GB quoted for the 500 nodes / 50 directives example. Drop both terms and recompute the examples.
- Make the agent run interval scaling explicit, and fix a rollup that did not follow from the per-day figure it was derived from.
    
# Settings table (performance.adoc):
    
- `rudder_save_db_compliance_levels` does not exist any more, remove it.
- The compliance mode setting is `rudder_compliance_mode`, not `reporting_mode`.
- Point the settings API link at the current API version.
    
# PostgreSQL tuning (performance.adoc, procedures.adoc, requirements.adoc):
    
- Remove the suggested `wal_buffers` values. Since PostgreSQL 9.1 the default  (-1) derives it from shared_buffers, 1/32 capped at one WAL segment, which gives 16MB and 8MB for the two suggested shared_buffers values. The documented 4MB and 1MB were therefore 4x and 8x smaller than what PostgreSQL chooses by itself. Tell operators who applied the previous advice to remove the line and restart, since the parameter can only be set at server start.
- `VACUUM FULL archivedruddersysevents` cannot work, the table was dropped in 8.2. Remove it.
- Warn that VACUUM FULL needs free space at least equal to the table size, which matters as it is typically run because the partition is nearly full.
- Describe autovacuum accurately: it makes space reusable, it does not return it to the filesystem nor prevent bloat by itself.
- `psql -u` is not a psql option, use -U, and -h so that password authentication applies.
- State the minimum PostgreSQL version in the requirements.
